### PR TITLE
Add dependency requirement in README and add more device generic Arduino on darwin

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,6 +6,9 @@ Tested on Python 2.7 with:
  - Ubuntu/Mint (12.10 & 13.04)
  - OSX
  - Windows 95 & 7
+
+Dependency requirement:
+ - astm-serial (pip2 install astm-serial)
  
 Aruino Versions:
  - Uno

--- a/tool.py
+++ b/tool.py
@@ -135,7 +135,7 @@ def clearFlash():
 if "linux" in sys.platform:
     possibleSerialPorts = [d for d in os.listdir("/dev") if "ttyACM" in d]
 elif sys.platform == "darwin":
-    possibleSerialPorts = [d for d in os.listdir("/dev") if "tty.usbserial" in d or "tty.usbmodem" in d]
+    possibleSerialPorts = [d for d in os.listdir("/dev") if "tty.usbserial" in d or "tty.usbmodem" in d or "cu.wchusbserial" in d or "cu.usbmodem" in d]
 else:
     possibleSerialPorts = ["COM1", "COM2", "COM3", "COM4"]
 

--- a/tool.py
+++ b/tool.py
@@ -133,7 +133,7 @@ def clearFlash():
 
 # Start the serial port up.  NB this is *nix specific, so needs changing for windows users.
 if "linux" in sys.platform:
-    possibleSerialPorts = [d for d in os.listdir("/dev") if "ttyACM" in d]
+    possibleSerialPorts = [d for d in os.listdir("/dev") if "ttyACM" in d or "ttyUSB" in d]
 elif sys.platform == "darwin":
     possibleSerialPorts = [d for d in os.listdir("/dev") if "tty.usbserial" in d or "tty.usbmodem" in d or "cu.wchusbserial" in d or "cu.usbmodem" in d]
 else:


### PR DESCRIPTION
First of all, I will thank you for your great work!

* Add dependency requirement in README.
The fist try, i installed the libary "serial"(pip2 install serial), which is obviously wrong. After some research with pip2 search, I found the right one: astm-serial. May the new README entry can help some new users.

* Add darwin usb serial detection support for some Generic Arduinos (tested with Elegoo UNO, AZDelivery UNO).
I know, this is may very device specific. Especially the part with "cu.usbmodem"  concerns me. I plugged my old 3G modem, which has another label, so this should not stand in conflict with a real usb modem.